### PR TITLE
Fix type signature for push!(filter::AbstractCuckooFilter, x...).

### DIFF
--- a/src/cuckoo/filter.jl
+++ b/src/cuckoo/filter.jl
@@ -354,7 +354,7 @@ function pushfingerprint(filter::AbstractCuckooFilter, fingerprint, index)
     # Attempt to push fingerprint to primary index
     success = putinfilter!(filter, index, fingerprint)
     if success
-        return nothing
+        return true
     end
 
     # Kick the fingerprint around until we find an empty spot, or MAX_KICKS has
@@ -363,7 +363,7 @@ function pushfingerprint(filter::AbstractCuckooFilter, fingerprint, index)
         index = otherindex(filter, index, fingerprint)
         success = putinfilter!(filter, index, fingerprint)
         if success
-            return nothing
+            return true
         end
         # Replace fingerprint with ejected fingerprint
         fingerprint = kick!(filter, index, fingerprint, rand(1:4))
@@ -371,7 +371,7 @@ function pushfingerprint(filter::AbstractCuckooFilter, fingerprint, index)
 
     filter.ejected = fingerprint
     filter.ejectedindex = index
-    return nothing
+    return false
 end
 
 """

--- a/test/cuckoo_filter.jl
+++ b/test/cuckoo_filter.jl
@@ -28,6 +28,36 @@ y = SmallCuckoo{12}(1<<4)
 @test eltype(y) == Probably.Bucket64{13}
 end
 
+@testset "Push!" begin
+for T in (FastCuckoo, SmallCuckoo)
+    params = constrain(T, fpr=0.001, capacity=100)
+    x = T{params.F}(params.nfingerprints)
+
+    rands = rand(10)
+    @test all(!(r in x) for r in rands)
+
+    for r in rands
+        @test push!(x, r)
+    end
+
+    @test all(r in x for r in rands)
+
+    # Try pushing multiple values at once
+    rands = rand(5)
+    @test push!(x, rands...)
+    @test all(r in x for r in rands)
+
+    # A push! into a full cuckoo filter should fail and return false
+    # We test this by filling the filter well beyond capacity...
+    for r in rand(5_000)
+        push!(x, r)
+    end
+
+    # ... and then trying to push another item into the filter
+    @test !(push!(x, rand()))
+end
+end
+
 @testset "Equality and hasing" begin
 for T in (FastCuckoo{12}, SmallCuckoo{12})
     x = T(1<<10)


### PR DESCRIPTION
Modify the `pushfingerprint` function to always return `Bool` rather than
`Union{Bool,Nothing}`, and adds some more tests for the `push!` function.
Closes #8.